### PR TITLE
Update evmqtt.py

### DIFF
--- a/evmqtt.py
+++ b/evmqtt.py
@@ -49,7 +49,7 @@ class Watcher:
 # The callback for when the client receives a CONNACK response from the server.
 
 
-def on_connect(client, rc):
+def on_connect(client, userdata, flags, rc):
     log("Connected with result code " + str(rc))
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.


### PR DESCRIPTION
the on_connect method needs to have the additional variables added to properly update with the newer versions of the paho client.  Once these variables are added the scripts works as intended